### PR TITLE
Compatibility updates for node 0.10

### DIFF
--- a/src/nfc.cc
+++ b/src/nfc.cc
@@ -11,8 +11,6 @@ namespace {
 
     void NFCRead(uv_work_t* req);
     void AfterNFCRead(uv_work_t* req);
-    
-    NODE_MODULE(nfc, init)
 
     struct NFC: ObjectWrap {
         static Handle<Value> New(const Arguments& args);
@@ -162,3 +160,5 @@ namespace {
     }
 
 }
+
+NODE_MODULE(nfc, init)


### PR DESCRIPTION
Had to explicitly cast one of the arguments for compatibility with the latest node. Without this, it will not build and the error below will be encountered:

```
  CXX(target) Release/obj.target/nfc/src/nfc.o
../src/nfc.cc:72:9: error: no matching function for call to 'uv_queue_work'
        uv_queue_work(uv_default_loop(), req, NFCRead, AfterNFCRead);
        ^~~~~~~~~~~~~
/Users/dsnigier/.node-gyp/0.10.22/deps/uv/include/uv.h:1432:15: note: candidate function not viable: no known conversion from 'void (uv_work_t *)' to
      'uv_after_work_cb' (aka 'void (*)(uv_work_t *, int)') for 4th argument
UV_EXTERN int uv_queue_work(uv_loop_t* loop, uv_work_t* req,
              ^
../src/nfc.cc:84:9: error: no matching function for call to 'uv_queue_work'
        uv_queue_work(uv_default_loop(), req, NFCRead, AfterNFCRead);
        ^~~~~~~~~~~~~
/Users/dsnigier/.node-gyp/0.10.22/deps/uv/include/uv.h:1432:15: note: candidate function not viable: no known conversion from 'void (uv_work_t *)' to
      'uv_after_work_cb' (aka 'void (*)(uv_work_t *, int)') for 4th argument
UV_EXTERN int uv_queue_work(uv_loop_t* loop, uv_work_t* req,
              ^
2 errors generated.
```
