### PR TITLE
Fixed syntax on nfc_modulation declaration

### DIFF
--- a/src/nfc.cc
+++ b/src/nfc.cc
@@ -10,11 +10,11 @@
 using namespace v8;
 using namespace node;
 
-
 static const nfc_modulation nmMifare = {
-  .nmt = NMT_ISO14443A,
-  .nbr = NBR_106,
+  NMT_ISO14443A,
+  NBR_106,
 };
+
 static uint8_t keys[] = {
   0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
   0xd3, 0xf7, 0xd3, 0xf7, 0xd3, 0xf7,


### PR DESCRIPTION
Build was failing for me on:

```
  CXX(target) Release/obj.target/nfc/src/nfc.o
../src/nfc.cc:15:3: error: expected primary-expression before ‘.’ token
../src/nfc.cc:16:3: error: expected primary-expression before ‘.’ token
```

This fixes it for me, I'm not aware of any possible implications though?