### PR TITLE
Fixed  nfc.parse  typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.swp
 
 pids
 logs

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ exports.nfc.parse = function(data) {
 
   results = [];
 
-  for (i = 0, bytes = data.toJSON(); i < bytes.length; i += tlv.len) {
+  for (i = 0, bytes = data.toJSON().data; i < bytes.length; i += tlv.len) {
     tlv = { type: bytes[i++] };
     if ((tlv.type === 0xfe) || (i >= bytes.length)) {
       results.push(tlv);


### PR DESCRIPTION
The data.toJSON() in the nfc.parse function returns JSON representation of the Buffer, not the bytes.