### PR TITLE
Added support for synchronous write and read to mifare-ultralight  card

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,8 @@
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         ".",
-        "/usr/local/include/"
+        "/usr/local/include/",
+        "/usr/include/node"
       ],
   } ]
 }

--- a/index.js
+++ b/index.js
@@ -41,6 +41,45 @@ exports.nfc.parse = function(data) {
   return results;
 };
 
+//------------------------------------------------------------------------------
+//
+// manublk (Buffer): the manufacture block.
+//------------------------------------------------------------------------------
+exports.nfc.parseManufactureBlk = function(manublk) {
+    var i, manudata, uid, lock, cc;
+    manudata = {};
+    uid = [];
+    lock= Array(2); // lock bytes
+    cc = [];    // Capability container
+
+    for (i=0; i<=2; i++) {
+        uid.push(manublk[i]);
+    }
+    for (i=4; i<=7; i++) {
+        uid.push(manublk[i]);
+    }
+    manudata.uid = uid;
+
+    manudata.cb0 = manublk[3];  // Check byte 0: CT(0x88) ^ SN0 ^ SN1 ^ SN2
+    manudata.cb1 = manublk [8]; // Check byte 1: SN3 ^ SN4 ^ SN5 ^ SN6
+
+    manudata.internal = manublk[9];
+    
+    lock[0] = manublk[10];
+    lock[1] = manublk[11];
+    manudata.lock = lock;
+
+    for (i=12; i<16; i++) {
+        cc.push(manublk[i]);
+    }
+    manudata.cc = cc;
+
+    return manudata;
+    
+}
+
+
+
 exports.nfc.scan = function() {
   var device, devices, i, info, j, k, kv, mod, mods, prop, props, protocol, results, speeds, v, x;
 

--- a/src/mifare.h
+++ b/src/mifare.h
@@ -81,7 +81,7 @@ typedef union {
 // Reset struct alignment to default
 #  pragma pack()
 
-bool    nfc_initiator_mifare_cmd(nfc_device *pnd, const mifare_cmd mc, const uint8_t ui8Block, mifare_param *pmp);
+///bool    nfc_initiator_mifare_cmd(nfc_device *pnd, const mifare_cmd mc, const uint8_t ui8Block, mifare_param *pmp);
 
 // Compiler directive, set struct alignment to 1 uint8_t for compatibility
 #  pragma pack(1)

--- a/src/nfc.cc
+++ b/src/nfc.cc
@@ -203,7 +203,6 @@ namespace {
             this->data = (char*)malloc(data_size);
             memcpy(this->data, data, data_size);
         }
-
       private:
         char        *deviceID;
         char        *name;
@@ -410,7 +409,6 @@ namespace {
                         command[0] = MC_READ;
                         command[1] = n;
                         res = nfc_initiator_transceive_bytes(baton->pnd, command, 2, dp, cnt, -1);
-                        printf("Read page %ld with %d bytes\n", n, res);
                         if (res >= 0) continue;
 
                         if (res != NFC_ERFTRANS) {
@@ -457,7 +455,15 @@ namespace {
     /*
      * Read NTAG21x sector (4 blocks, 16 pages, or 64 bytes).
      *
-     * NOTE: Device document: http://www.nxp.com/documents/data_sheet/NTAG213_215_216.pdf
+     * Args:
+     *  start sector #: int 
+     *
+     * Returns:
+     *  tag object: dictionary
+     *
+     * NOTE: 
+     *  Device document: http://www.nxp.com/documents/data_sheet/NTAG213_215_216.pdf
+     *
      */
     NAN_METHOD(NFC::ReadSector) {
         NFC* baton = ObjectWrap::Unwrap<NFC>(info.This());
@@ -532,7 +538,6 @@ namespace {
             //printf("Reading sector of device %s:%s with tag: %s\n", tag->deviceID, tag->name, tag->tag);
             //printf("tag data: %s\n", tag->data);
 
-            //Local<Object> ret = Object::New(isolate, tag);
             Local<Object> object = Nan::New<Object>();
             tag->AddToNodeObject(object);
             delete tag;
@@ -542,9 +547,15 @@ namespace {
             break;
         }    
     }
+
     /*
-     * Write blocks to NFC card
-     * TODO: Refactor with `AsyncProcessWorker`
+     * Write tag data synchronously.
+     *
+     * Args:
+     *  tag data: node buffer object.
+     *
+     * Returns:
+     *  The number of pages written: int
      */
     NAN_METHOD(NFC::Write) {
         Nan::HandleScope scope;
@@ -766,7 +777,6 @@ namespace {
 
         info.GetReturnValue().Set(object);
     }
-
 
     NAN_MODULE_INIT(init) {
         Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(NFC::New);


### PR DESCRIPTION
- Added `startReadWorker` to start listening tag data and report `read` callback. Also the `start` function won't start the read worker by default, need to call `startReadWorker` manually.
- nfc_device.readTagSector(sector_index)
- nfc_device.write(buffer)
